### PR TITLE
Enhancements and Updates to Terraform AWS GitHub Backup Module

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 0.5.2
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:README.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:locals.tf]
+search = module_version = "{current_version}"
+replace = module_version = "{new_version}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # terraform-aws-github-backup
-TBD
+
+This module automates the deployment of infrastructure for
+the [InfraHouse GitHub Backup](https://github.com/apps/infrahouse-github-backup) application,
+which is designed to back up GitHub repositories.
+
+The instances within the Auto Scaling Group perform the following tasks:
+- Read app installations and their configurations.
+- Create an in-memory backup copy of the repositories.
+- Upload the backups to an S3 bucket specified in the installation configuration.
+
+**Note:** The backup of a repository is stored on an ephemeral disk,
+meaning it is not retained after the instance is terminated. This design choice enhances safety and security.
+
+On the client side, the backups are configured by
+the [github-backup-configuration](https://github.com/infrahouse/terraform-aws-github-backup-configuration)
+module.
+
+## Usage
+
+```hcl
+module "terraform-aws-github-backup" {
+  source  = "registry.infrahouse.com/infrahouse/github-backup/aws"
+  version = "0.5.2"
+
+  app_key_secret           = module.infrahouse-github-backup-app-key.secret_name
+  subnets                  = module.management.subnet_private_ids
+  instance_type            = "t3a.small"
+  environment              = var.environment
+  root_volume_size         = 60
+  smtp_credentials_secret = module.smtp_credentials.secret_name
+}
+```
 ## Requirements
 
 | Name | Version |

--- a/datasources.tf
+++ b/datasources.tf
@@ -58,6 +58,16 @@ data "aws_iam_policy_document" "default_permissions" {
       data.aws_secretsmanager_secret.app_key_secret.arn
     ]
   }
+  # Allow reading tags by ih-ec2 tags
+  # The "ec2:DescribeInstances" action doesn't support Conditions, so we have to use the wildcard
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+    ]
+    resources = [
+      "*"
+    ]
+  }
 }
 
 data "aws_secretsmanager_secret" "app_key_secret" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  module_version = "0.5.2"
+
   default_module_tags = {
     environment : var.environment
     service : var.service_name
@@ -8,6 +10,7 @@ locals {
   default_asg_tags = merge(
     {
       Name : "infrahouse-github-backup"
+      module_version : local.module_version
     },
     local.default_module_tags
   )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-black ~= 24.4
-boto3 ~= 1.26
-infrahouse-toolkit ~= 2.0
-myst-parser ~= 2.0
-pytest ~= 7.3
-pytest-timeout ~= 2.1
-pytest-rerunfailures ~= 12.0
-requests ~= 2.32
+pytest-infrahouse ~= 0.9
+infrahouse-core ~= 0.16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,90 +1,14 @@
-import json
-import time
-from textwrap import dedent
-
-import boto3
-import pytest
 import logging
-from os import path as osp
 
-from infrahouse_toolkit.logging import setup_logging
-from infrahouse_toolkit.terraform import terraform_apply
-from requests import get
+from infrahouse_core.logging import setup_logging
 
 # "303467602807" is our test account
 TEST_ACCOUNT = "303467602807"
-TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/ecs-tester"
+# TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/ecs-tester"
 DEFAULT_PROGRESS_INTERVAL = 10
-TRACE_TERRAFORM = False
-DESTROY_AFTER = True
 UBUNTU_CODENAME = "jammy"
 
 LOG = logging.getLogger(__name__)
-REGION = "us-east-2"
-TEST_ZONE = "ci-cd.infrahouse.com"
 TERRAFORM_ROOT_DIR = "test_data"
 
 setup_logging(LOG, debug=True)
-
-
-@pytest.fixture(scope="session")
-def aws_iam_role():
-    sts = boto3.client("sts")
-    return sts.assume_role(
-        RoleArn=TEST_ROLE_ARN, RoleSessionName=TEST_ROLE_ARN.split("/")[1]
-    )
-
-
-@pytest.fixture(scope="session")
-def boto3_session(aws_iam_role):
-    return boto3.Session(
-        aws_access_key_id=aws_iam_role["Credentials"]["AccessKeyId"],
-        aws_secret_access_key=aws_iam_role["Credentials"]["SecretAccessKey"],
-        aws_session_token=aws_iam_role["Credentials"]["SessionToken"],
-    )
-
-
-@pytest.fixture(scope="session")
-def ec2_client(boto3_session):
-    assert boto3_session.client("sts").get_caller_identity()["Account"] == TEST_ACCOUNT
-    return boto3_session.client("ec2", region_name=REGION)
-
-
-@pytest.fixture(scope="session")
-def ec2_client_map(ec2_client, boto3_session):
-    regions = [reg["RegionName"] for reg in ec2_client.describe_regions()["Regions"]]
-    ec2_map = {reg: boto3_session.client("ec2", region_name=reg) for reg in regions}
-
-    return ec2_map
-
-
-@pytest.fixture()
-def route53_client(boto3_session):
-    return boto3_session.client("route53", region_name=REGION)
-
-
-@pytest.fixture()
-def elbv2_client(boto3_session):
-    return boto3_session.client("elbv2", region_name=REGION)
-
-
-@pytest.fixture(scope="session")
-def service_network(boto3_session):
-    terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "service-network")
-    # Create service network
-    with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
-        fp.write(
-            dedent(
-                f"""
-                role_arn = "{TEST_ROLE_ARN}"
-                region   = "{REGION}"
-                """
-            )
-        )
-    with terraform_apply(
-        terraform_module_dir,
-        destroy_after=DESTROY_AFTER,
-        json_output=True,
-        enable_trace=TRACE_TERRAFORM,
-    ) as tf_service_network_output:
-        yield tf_service_network_output

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -2,20 +2,15 @@ import json
 from os import path as osp
 from textwrap import dedent
 
-from infrahouse_toolkit.terraform import terraform_apply
+from pytest_infrahouse import terraform_apply
 
 from tests.conftest import (
     LOG,
-    TRACE_TERRAFORM,
-    DESTROY_AFTER,
-    TEST_ZONE,
-    TEST_ROLE_ARN,
-    REGION,
     TERRAFORM_ROOT_DIR,
 )
 
 
-def test_module(service_network, ec2_client):
+def test_module(service_network, keep_after, test_role_arn, aws_region):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
 
     # Create ECS with httpd container
@@ -24,17 +19,23 @@ def test_module(service_network, ec2_client):
         fp.write(
             dedent(
                 f"""
-                role_arn = "{TEST_ROLE_ARN}"
-                region   = "{REGION}"
+                region   = "{aws_region}"
                 subnets  = {json.dumps(subnet_public_ids)}
                 """
             )
         )
+        if test_role_arn:
+            fp.write(
+                dedent(
+                    f"""
+                    role_arn      = "{test_role_arn}"
+                    """
+                )
+            )
 
     with terraform_apply(
         terraform_module_dir,
-        destroy_after=DESTROY_AFTER,
+        destroy_after=not keep_after,
         json_output=True,
-        enable_trace=TRACE_TERRAFORM,
     ) as tf_httpd_output:
         LOG.info(json.dumps(tf_httpd_output, indent=4))

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,7 @@ variable "instance_type" {
 variable "key_pair_name" {
   description = "SSH keypair name to be deployed in EC2 instances"
   type        = string
+  default     = null
 }
 
 variable "max_instance_lifetime_days" {


### PR DESCRIPTION
   - The README file was significantly expanded to include a detailed description of the module's purpose, functionality, and usage instructions.
   - A new section titled "Usage" was added, providing an example of how to use the module with specific parameters.
   - A new statement was added to allow reading EC2 instance tags by including the `ec2:DescribeInstances` action.
   - A new local variable `module_version` was introduced in `locals.tf`, set to `0.5.2`, and it is now included in the default Auto Scaling Group tags.
   - The key_pair_name variable is made optional as long as we rely
     more. When the value is null, the key pair will be generated.
     on SSM for instance access.
   - Use infrahouse pytest plugin for tests . https://pypi.org/project/pytest-infrahouse/
