### PR TITLE
Use self-hosted runners

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   publish:
     name: 'Publish Module'
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "Linux"]
     environment: production
     timeout-minutes: 60
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest


### PR DESCRIPTION
The self-hosted runners have pre-installed dependencies. Use them.