### PR TITLE
Setup Python in workflow

### DIFF
--- a/.github/workflows/terraform-CD.yml
+++ b/.github/workflows/terraform-CD.yml
@@ -38,6 +38,11 @@ jobs:
           role-session-name: github-actions
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.13'
+
       # Prepare Python environment
       - name: Setup Python Environment
         run: make bootstrap


### PR DESCRIPTION
Ironically, pip isn't installed in self-hosted instances.

That's why - create a virtualenv and use it for the job.
