### PR TITLE
fix: S3 replication V2 schema compliance and backup container fixes

### DIFF
--- a/container/backup.py
+++ b/container/backup.py
@@ -13,6 +13,7 @@ Environment variables (set by ECS task definition):
     AWS_DEFAULT_REGION         - AWS region (auto-set by ECS)
 """
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -27,7 +28,8 @@ import requests
 from infrahouse_core.aws import Secret
 from infrahouse_core.logging import setup_logging
 
-LOG = setup_logging(__name__)
+LOG = logging.getLogger(__name__)
+setup_logging(LOG)
 
 # ── Configuration ───────────────────────────────────────────────
 

--- a/s3_replication.tf
+++ b/s3_replication.tf
@@ -148,6 +148,10 @@ resource "aws_s3_bucket_replication_configuration" "backup" {
     status = "Enabled"
     filter {}
 
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
     destination {
       bucket        = aws_s3_bucket.replica.arn
       storage_class = "STANDARD"


### PR DESCRIPTION
## Summary
- Add required `delete_marker_replication` block to S3 replication configuration.
  The V2 schema (triggered by `filter {}`) requires it; without it, `PutBucketReplication`
  returns `400 InvalidRequest`.
- Fix `backup.py` crash on startup: add missing `import logging` and correct
  `setup_logging()` call to pass a logger object instead of a string.
- Anchor `grep` in Makefile release targets (`grep ^new_version`) to prevent
  matching `tag_name = {new_version}` from `.bumpversion.cfg`.
- Add CloudWatch log dump to test on ECS task failure for easier debugging.

## Test plan
- [x] Reproduced S3 replication error with `make test-keep TEST_REGION=us-west-1`
- [x] Reproduced backup.py `AttributeError` via CloudWatch logs
- [x] Verified full test pass after fixes (`1 passed in 161.32s`)
